### PR TITLE
Add string results from Intezer

### DIFF
--- a/intezer.py
+++ b/intezer.py
@@ -363,6 +363,7 @@ class ALIntezerApi(IntezerApi):
         logged = False
         while True:
             try:
+                #Fetch String analysis results from the Intezer API
                 results = IntezerApi.request_with_refresh_expired_access_token(
                     self=self,
                     method="GET",
@@ -795,12 +796,16 @@ class Intezer(ServiceBase):
 
     @staticmethod
     def _process_strings(strings, parent_section: ResultSection):
+        #Format String results into tables
+        #Families: Specific malware strain or codebase
+        #Family Type: General category/classification of malware
 
         families = []
         family_count = []
         string_list = []
         family_type = []
 
+        #Create lists of strings along with categories and counts for each category
         for string in strings:
             if "families" in string:
                 if string['families'][0]['family_name'] in families:
@@ -843,6 +848,7 @@ class Intezer(ServiceBase):
             string_family_table.add_row(TableRow(row))
         string_family_table.set_heuristic(21)
 
+        #Create sub tables for each category of malware and display the strings and family
         for type in family_type:
             if type == "common": continue
             family_section = ResultTableSection("String Family: " + type, auto_collapse=True)

--- a/intezer.py
+++ b/intezer.py
@@ -836,7 +836,7 @@ class Intezer(ServiceBase):
         sorted_families = list(sorted_families)
         sorted_family_count = list(sorted_family_count)
 
-        string_family_table = ResultTableSection("String Family Count")
+        string_family_table = ResultTableSection("Total String Count per Family")
         string_family_table.set_column_order(["Family Name", "String Count"])
 
         for i in range(len(families)):

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -146,6 +146,11 @@ heuristics:
     score: 0
     filetype: .*
     description: Results from Intezer analysis
+  - heur_id: 21
+    name: Intezer found malicious strings
+    score: 0
+    filetype: .*
+    description: Results from Intezer string analysis
 docker_config:
   allow_internet_access: true
   image: ${REGISTRY}cccs/assemblyline-service-intezer:$SERVICE_TAG


### PR DESCRIPTION
I added the string results from Intezer into a new heuristic. There is a table at the top of the heruistic that shows the total number of strings per string family. Following that are tables for each family type that shows the associated strings as well as the families that string belongs to.
![image](https://github.com/user-attachments/assets/df5a0ced-4967-453a-8945-4e7e60af580b)
![image](https://github.com/user-attachments/assets/be3bd162-e5e8-47ae-bd7a-ac1556e3ac30)
